### PR TITLE
Refactor send_discord_notification to accept webhook_url parameter

### DIFF
--- a/app/monitor.py
+++ b/app/monitor.py
@@ -19,7 +19,7 @@ def check_health(application):
         if response.status_code != 200:
             send_discord_notification(application.get("webhook_url", DEFAULT_WEBHOOK_URL), f"🚨 {application['name']} is unhealthy: Status code {response.status_code}")
     except requests.exceptions.RequestException as e:
-        send_discord_notification(f"🚨 {application['name']} health check failed: {str(e)}")
+        send_discord_notification(application.get("webhook_url", DEFAULT_WEBHOOK_URL), f"🚨 {application['name']} health check failed: {str(e)}")
 
 def main():
     while True:

--- a/app/monitor.py
+++ b/app/monitor.py
@@ -1,13 +1,13 @@
 import requests
 import time
-from app.config import APPLICATIONS, DISCORD_WEBHOOK_URL, CHECK_INTERVAL
+from app.config import APPLICATIONS, DEFAULT_WEBHOOK_URL, CHECK_INTERVAL
 
-def send_discord_notification(message):
+def send_discord_notification(webhook_url, message):
     data = {
         "content": message
     }
     try:
-        response = requests.post(DISCORD_WEBHOOK_URL, json=data)
+        response = requests.post(webhook_url, json=data)
         if response.status_code != 204:
             print(f"Failed to send notification: {response.status_code}")
     except Exception as e:
@@ -17,7 +17,7 @@ def check_health(application):
     try:
         response = requests.get(application['url'])
         if response.status_code != 200:
-            send_discord_notification(f"🚨 {application['name']} is unhealthy: Status code {response.status_code}")
+            send_discord_notification(application.get("webhook_url", DEFAULT_WEBHOOK_URL), f"🚨 {application['name']} is unhealthy: Status code {response.status_code}")
     except requests.exceptions.RequestException as e:
         send_discord_notification(f"🚨 {application['name']} health check failed: {str(e)}")
 

--- a/app/monitor.py
+++ b/app/monitor.py
@@ -11,6 +11,8 @@ def send_discord_notification(webhook_url, message):
         if response.status_code != 204:
             print(f"Failed to send notification: {response.status_code}")
     except Exception as e:
+        print(f"Error sending Discord notification: {str(e)}")
+        logging.error(f"Failed to send Discord notification: {str(e)}", exc_info=True)
         print(f"Error sending notification: {e}")
 
 def check_health(application):


### PR DESCRIPTION
## Summary by Sourcery

Refactor the send_discord_notification function to accept a webhook_url parameter, enabling the use of different webhook URLs for different applications. Update the check_health function to utilize this new parameter, defaulting to a DEFAULT_WEBHOOK_URL if no specific URL is provided for an application.

Enhancements:
- Refactor the send_discord_notification function to accept a webhook_url parameter, allowing for more flexible notification routing.